### PR TITLE
Replace all: 'NZ Ruby' → 'Ruby New Zealand'

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
     <!--[if lt IE 9]>
     <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
-    <title>NZ Ruby</title>
+    <title>Ruby New Zealand</title>
   </head>
 
   <body>
@@ -20,7 +20,7 @@
       <div class="inner">
 
         <header>
-          <h1>NZ Ruby</h1>
+          <h1>Ruby New Zealand</h1>
           <h2>Ruby in Aotearoa New Zealand</h2>
         </header>
 
@@ -57,7 +57,7 @@
         </section>
 
         <footer>
-          NZ Ruby is maintained by <a href="https://github.com/nzruby">nzruby</a>
+          Ruby New Zealand is maintained by <a href="https://github.com/nzruby">nzruby</a>
         </footer>
 
         <script type="text/javascript">


### PR DESCRIPTION
Rebranding!
