### PR TITLE
Point to correct Twitter account @RubyNewZealand

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
 
         <section id="comms" class="clearfix">
           <a href="http://slack.ruby.nz/" id="irc-chat" class="button"><i class="icon-list-alt"></i> Slack Chat</a>
-          <a href="https://twitter.com/NewZealandRuby" id="twitter" class="button"><i class="icon-twitter"></i> Twitter</a>
+          <a href="https://twitter.com/RubyNewZealand" id="twitter" class="button"><i class="icon-twitter"></i> Twitter</a>
         </section>
 
         <section id="main_content">


### PR DESCRIPTION
The GitHub account should really be made consistent too, i.e. rubynz instead of nzruby

This should hopefully stop a lot of those rugby tweets..
