### PR TITLE
🛠 Use native CSS smooth-scroll instead of JS

### DIFF
--- a/javascripts/main.js
+++ b/javascripts/main.js
@@ -1,28 +1,8 @@
 /*global $*/
 
 $(document).ready(function () {
-  smoothScroll();
   mobileNav();
 });
-
-function smoothScroll () {
-  var anchorPattern = /^#/;
-
-  $('.menu a').click(function (e) {
-    var href = $(e.target).attr('href');
-
-    // Don't try and smooth scroll external links
-    if (!anchorPattern.test(href)) {
-      return true;
-    }
-
-    e.preventDefault();
-
-    $('html, body').animate({
-      scrollTop: $(href).offset().top - 20
-    }, 300);
-  });
-}
 
 function mobileNav () {
   var $sidebar = $('aside.sidebar');

--- a/stylesheets/stylesheet.css
+++ b/stylesheets/stylesheet.css
@@ -4,6 +4,7 @@ body, html {
   font: 14pt/1.6em "Poppins", sans-serif;
   margin: 0.5em auto;
   height: 100%;
+  scroll-behavior: smooth;
 }
 
 .pure-g [class *= "pure-u"] {


### PR DESCRIPTION
This change replaces the smooth-scroll function defined in JS with the CSS property `scroll-behaviour: smooth`.

[More about scroll-behaviour here, including browser support](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-behavior).

Saves a few lines of Javascript! Progressive enhancement! 😘 