### PR TITLE
Update members for 2019 AGM

### DIFF
--- a/index.html
+++ b/index.html
@@ -151,17 +151,19 @@
 
           <section id="current-committee">
             <h2>Current Committee</h2>
-            <p>After the vote held during the AGM held on the Ruby NZ Slack on May 16, 2018 the committee was:</p>
+            <p>After the vote held during the AGM held on the Ruby NZ Slack on April 8, 2019 the committee was:</p>
             <ul>
-              <li><strong>President:</strong> <a href="https://twitter.com/nz_cub3y" target="_blank">Charles Peach</a></li>
-              <li><strong>Secretary:</strong> <a href="https://twitter.com/containsulfite" target="_blank">Mai Nguyen</a></li>
+              <li><strong>President:</strong> <a href="https://twitter.com/merxplat" target="_blank">Merrin Macleod</a></li>
+              <li><strong>Secretary:</strong> <a href="https://twitter.com/AndrewPett1" target="_blank">Andrew Pett</a></li>
               <li><strong>Treasurer:</strong> <a href="https://twitter.com/steveh7" target="_blank">Steve Hoeksema</a></li>
               <li>
                 <strong>General Members:</strong>
                 <ul>
-                  <li><a href="https://twitter.com/ur5us" target="_blank">Juri Hahn</a></li>
-                  <li><a href="https://twitter.com/merxplat" target="_blank">Merrin Macleod</a></li>
-                  <li><a href="https://twitter.com/AndrewPett1" target="_blank">Andrew Pett</a></li>
+                  <li>Laura Harnett</li>
+                  <li><a href="https://twitter.com/four_seven" target="_blank">Mathew Hartley</a></li>
+                  <li>Anthony Mace</li>
+                  <li><a href="https://twitter.com/aupajo" target="_blank">Pete Nicholls</a></li>
+                  <li>Rebecca Pinheiro</li>
                 </ul>
               </li>
             </ul>
@@ -170,6 +172,9 @@
           <section id="past-committee">
             <h2>Past Committee Members</h2>
             <ul>
+              <li><a href="https://twitter.com/ur5us" target="_blank">Juri Hahn</a> (general member 2016-2017, 2018-2019)</li>
+              <li><a href="https://twitter.com/nz_cub3y" target="_blank">Charles Peach</a> (general member 2016-2018, president 2018-2019)</li>
+              <li><a href="https://twitter.com/containsulfite" target="_blank">Mai Nguyen</a> (secretary 2018-2019)</li>
               <li><a href="https://twitter.com/charlieablettnz" target="_blank">Charlie Ablett</a> (general member 2018-2019)</li>
               <li><a href="https://twitter.com/ioquatix" target="_blank">Samuel Williams</a> (general member 2018-2019)</li>
               <li><a href="https://twitter.com/a_wagener" target="_blank">Amanda Wagener</a> (general member 2017-2018 and 2014-2015, president 2016-2017, secretary 2015-2016)</li>
@@ -182,19 +187,14 @@
               <li><a href="https://twitter.com/parndt" target="_blank">Philip Arndt</a> (president 2014-2016)</li>
               <li><a href="https://twitter.com/megahbite" target="_blank">Megan Bowra-Dean</a> (general member 2015-2016)</li>
               <li>James Harton (general member 2014-2016)</li>
-              <li><a href="https://twitter.com/breccan" target="_blank">Breccan Mcleod-Lundy</a> (general member 2014-2015)</li>
+              <li><a href="https://twitter.com/breccan" target="_blank">Breccan McLeod-Lundy</a> (general member 2014-2015)</li>
               <li><a href="https://twitter.com/terrcin" target="_blank">Nahum Wild</a> (general member 2014-2015)</li>
             </ul>
           </section>
           <hr />
           <section id="slack-moderators">
             <h2>Slack Moderators</h2>
-            Members of the committee moderate Slack to make sure that we're all following the Code of Conduct. If you have questions or concerns, you can contact our moderators on Slack. They might not always be online, so send them a direct message if you need to talk to them.
-            <ul>
-              <li><strong>@charlie</strong> - Charlie Ablett</li>
-              <li><strong>@ur5us</strong> - Juri Hahn</li>
-              <li><strong>@ioquatix</strong> - Samuel Williams</li>
-            </ul>
+            Members of the committee moderate Slack to make sure that we're all following the Code of Conduct. If you have questions or concerns, you can contact one of the committee members on Slack. They might not always be online, so send them a direct message if you need to talk to them.
           </section>
         </div>
       </article>


### PR DESCRIPTION
- Update members after the 2019 AGM
- Remove former moderators from moderation section - will clarify responsibilities soon, but for now..