### PR TITLE
Layout: use absolute paths for assets

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -13,16 +13,16 @@
     <!--[if gt IE 8]><!-->
       <link rel="stylesheet" href="https://unpkg.com/purecss@0.6.2/build/grids-responsive-min.css">
     <!--<![endif]-->
-    <link rel="stylesheet" type="text/css" href="stylesheets/normalize.css" media="print" />
-    <link rel="stylesheet" type="text/css" href="stylesheets/stylesheet.css" media="screen" />
-    <link rel="stylesheet" type="text/css" href="stylesheets/pygment_trac.css" media="screen" />
-    <link rel="stylesheet" type="text/css" href="stylesheets/print.css" media="print" />
+    <link rel="stylesheet" type="text/css" href="/stylesheets/normalize.css" media="print" />
+    <link rel="stylesheet" type="text/css" href="/stylesheets/stylesheet.css" media="screen" />
+    <link rel="stylesheet" type="text/css" href="/stylesheets/pygment_trac.css" media="screen" />
+    <link rel="stylesheet" type="text/css" href="/stylesheets/print.css" media="print" />
     <!--[if lt IE 9]>
       <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
     <script src="https://use.fontawesome.com/5845f7da54.js"></script>
     <script src="https://code.jquery.com/jquery-3.1.1.min.js" integrity="sha256-hVVnYaiADRTO2PzUGmuLJr8BLUSjGIZsDYGmIJLv2b8=" crossorigin="anonymous"></script>
-    <script src="javascripts/main.js"></script>
+    <script src="/javascripts/main.js"></script>
 
     <title>{% if page.title %}{{ page.title }} – {% endif %}Ruby New Zealand</title>
   </head>
@@ -35,7 +35,7 @@
       <aside class="sidebar pure-u-2-3 pure-u-md-1-3 mobile-hidden">
         <div class="inner-container">
           <div class="mobile-hidden">
-            <img src="images/logo.png" class="logo" alt="Ruby New Zealand" />
+            <img src="/images/logo.png" class="logo" alt="Ruby New Zealand" />
           </div>
           <header class="mobile-hidden">
             <h1>Ruby New Zealand</h1>


### PR DESCRIPTION
Fixes page rendering for pages on nested paths.

At the moment, only the home page renders correctly because the asset paths are assumed to be relative to `/`. If we introduce sub-pages (e.g. `/my-custom-page/`), the rendering breaks.