### PR TITLE
Improve error handling in bin/setup

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -6,7 +6,7 @@ set -e
 function at_exit {
   local exit_status=$?
 
-  if [[ $exit_status -eq 1 ]]; then
+  if [[ ! $exit_status -eq 0 ]]; then
     echo
     echo "! Set-up failed. Please address the issues above and try again."
   fi


### PR DESCRIPTION
In the EXIT signal trap, the command displays an error message if any part of the set-up fails. However, to determine whether a command had failed, it was looking explicitly for an exit status of 1, which does not account for the [various error-indicating exit statuses a command may return](https://www.tldp.org/LDP/abs/html/exit-status.html). This changes it to simply look for a non-zero status.