### PR TITLE
Add strategy to website

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -48,6 +48,7 @@
             <a href="/events">Events</a>
             <a href="#code-of-conduct">Code of Conduct</a>
             <a href="#about-us">About us</a>
+            <a href="/strategy">Strategic Vision</a>
             <a href="#current-committee">Current Committee</a>
             <a href="#past-committee">Past Committee</a>
             <a href="#slack-moderators">Slack Moderators</a>

--- a/strategy.html
+++ b/strategy.html
@@ -9,9 +9,9 @@ layout: default
 
     <p>This is a strategic vision for Ruby NZ for 2019-2020. We will use this as a guide for the actions we take. </p>
 
-    <p>Our charter specifies the following purposes:</p>
+    <h2>Our charter</h2>
     <ul>
-    <li>Foster and support the Ruby programming language, its users, community and ecosystem in New Zealand;</li>
+    <li>Foster and support the Ruby programming language, its users, community and ecosystem in New Zealand.</li>
     <li>Advocate for Open Source in general, and the Ruby programming language in particular.</li>
     <li>Provide support for Ruby community events.</li>
     <li>Work with event organisers to ensure the Ruby community and events in New Zealand are safe and welcoming.</li>
@@ -54,7 +54,6 @@ layout: default
       <li>Our community has a more equal gender ratio compared to other open source communities in New Zealand. </li>
       <li>Our community welcomes people from many different cultural backgrounds, reflecting the diversity and cultural richness of Aotearoa New Zealand.</li>
     </ul>
-
 
   </div>
 </div>

--- a/strategy.html
+++ b/strategy.html
@@ -1,0 +1,60 @@
+---
+Title: Events
+layout: default
+---
+
+<div class="pure-g">
+  <div class="pure-u-1">
+    <h1>Strategic Vision</h1>
+
+    <p>This is a strategic vision for Ruby NZ for 2019-2020. We will use this as a guide for the actions we take. </p>
+
+    <p>Our charter specifies the following purposes:</p>
+    <ul>
+    <li>Foster and support the Ruby programming language, its users, community and ecosystem in New Zealand;</li>
+    <li>Advocate for Open Source in general, and the Ruby programming language in particular.</li>
+    <li>Provide support for Ruby community events.</li>
+    <li>Work with event organisers to ensure the Ruby community and events in New Zealand are safe and welcoming.</li>
+    </ul>
+
+    <p>This is where we want Ruby NZ to be in 2020.</p>
+
+    <h2>We want Ruby to be well-respected and continue to be used by organisations in New Zealand.</h2>
+    <p><i>What does this look like?</i></p>
+    <ul>
+      <li>We understand the pulse of the Ruby community, how Ruby is being used, and what we can do to help organisations continue to use it.</li>
+      <li>We have good partnerships with organisations that teach and use Ruby.</li>
+    </ul>
+
+    <h2>We want to celebrate and support contributions to the open source Ruby ecosystem.</h2>
+
+    <p><i>What does this look like?</i></p>
+    <ul>
+      <li>A wide variety of people share their knowledge with the community through talks, blog posts, and discussions.</li>
+      <li>People from the New Zealand community often contribute to big international projects and conferences. </li>
+    </ul>
+    
+    <h2>We want Ruby events to be regular, sustainable, and great.</h2>
+
+    <p><i>What does this look like?</i></p>
+
+    <ul>
+      <li>Meetups happen regularly in big cities, and sometimes happen in smaller centres.</li>
+      <li>We support events targeted at people learning to program, people who are considering career changes, and people underrepresented in our community.</li>
+      <li>We have a plan and schedule for larger events.</li>
+      <li>We support event organisers to share the load and draw on knowledge and expertise.</li>
+    </ul>
+
+    <h2> We want to foster a welcoming, diverse, and thriving community.</h2>
+
+    <p><i>What does this look like?</i></p>
+
+    <ul>
+      <li>People who are new to discussions or events feel able to contribute and want to come back.</li>
+      <li>Our community has a more equal gender ratio compared to other open source communities in New Zealand. </li>
+      <li>Our community welcomes people from many different cultural backgrounds, reflecting the diversity and cultural richness of Aotearoa New Zealand.</li>
+    </ul>
+
+
+  </div>
+</div>


### PR DESCRIPTION
This PR is to add the strategic vision for 2020 to the website; it's also a place for community members to give feedback on it. 

This strategy is based on the charter of the organisation and a SWOT analysis carried out by a subcommittee, which is available [here](https://docs.google.com/document/d/1h8FAQ-WovGOMjFrB7BXDsXEIo85OXT6OoCrxaLy9-k0).

A more readable version of the strategic vision is on the wiki [here](https://github.com/rubynz/www/wiki/Strategic-vision-for-2020).