### PR TITLE
Reflect Ruby Retreat postponement

### DIFF
--- a/events.html
+++ b/events.html
@@ -13,7 +13,7 @@ layout: default
     <ul>
         <li>
           <a href="http://retreat.ruby.nz">Ruby Retreat</a>:
-          The inaugural Ruby Retreat will be held at Mt Cheeseman on March 27-30, 2020.
+          The inaugural Ruby Retreat will be held at Mt Cheeseman on March 27-30, 2020. [Postponed due to NZ's COVID-19 response]
         </li>
         <li>
           <a href="http://kiwi.ruby.nz">Kiwi Ruby</a>:


### PR DESCRIPTION
We had to delay this event because of our country's response to
COVID-19.

It will be held again at a later date.