### PR TITLE
Remove twitter link from homepage.

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@ layout: default
 <section class="pure-g" id="join-the-community">
   <div class="pure-u-1">
     <h2>Join the Community</h2>
-    <p>For code chat, job listings, ruby help, keyboard nerdery, and banter, join us on <a href="mailto:secretary@ruby.nz?subject=Can I have RubyNZ Slack access please?">Slack</a>. We're also on Twitter at <a href="http://twitter.com/rubynewzealand">@RubyNewZealand</a>.</p>
+    <p>For code chat, job listings, ruby help, keyboard nerdery, and banter, join us on <a href="mailto:secretary@ruby.nz?subject=Can I have RubyNZ Slack access please?">Slack</a>.</p>
 
     <p></p>
   </div>
@@ -32,9 +32,6 @@ layout: default
     </a>
     <a href="https://github.com/rubynz">
       <i class="fa fa-github fa-3x" alt="Ruby NZ Github"></i>
-    </a>
-    <a href="http://twitter.com/rubynewzealand">
-      <i class="fa fa-twitter fa-3x" alt="Ruby NZ Twitter"></i>
     </a>
   </div>
 </section>


### PR DESCRIPTION
We thought Twitter/X was no longer that relevant for development world. We've not used the account for years.