### PR TITLE
Fix Christchurch link

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,7 +57,7 @@ layout: default
       WellRailed: Wellington's Ruby on Rails Community Group
     </li>
     <li>
-      <a href="http://christchurch.ruby.org.nz">Christchurch</a>:
+      <a href="http://christchurch.ruby.nz">Christchurch</a>:
       Super friendly group of programmers meeting monthly to discuss all things about the Ruby programming language.
     </li>
   </ul>


### PR DESCRIPTION
Since we've updated our site, the old domain no longer works. Ideally, we'd support both CNAMES on GH pages, but I don't think that's possible. Perhaps the ruby.org.nz domain administrator can redirect to ruby.nz?