### PR TITLE
Update Slack invite instruction

### DIFF
--- a/index.html
+++ b/index.html
@@ -164,14 +164,12 @@ layout: default
   <h2>Slack Moderators</h2>
   Members of the committee moderate Slack to make sure that we're all following the Code of Conduct. If you have questions or concerns, you can contact our moderators on Slack. They might not always be online, so send them a direct message if you need to talk to them.
   <ul>
-    <li>@ben tillman</li>
-    <li>@Hannah Oldroyd</li>
-    <li>@drlawler</li>
-    <li>@eadz</li>
-    <li>@mhaylock</li>
-    <li>@layerssss</li>
+    <li>@Ben Tillman</li>
+    <li>@Henry</li>
+    <li>@Mark Haylock</li>
+    <li>@Michael Yin</li>
+    <li>@Nathan Broadbent</li>
     <li>@parndt</li>
-    <li>@sarah.hay</li>
-    <li>@Edu Depetris</li>
+    <li>@Sarah Hay</li>
   </ul>
 </section>

--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@ layout: default
   </div>
   <div class="pure-u-1 social">
     <a href="mailto:secretary@ruby.nz?subject=Can I have Ruby Oceania Slack access please?">
-      <i class="fa fa-slack fa-3x" alt="Ruby NZ Slack"></i>
+      <i class="fa fa-slack fa-3x" alt="Ruby Oceania Slack"></i>
     </a>
     <a href="https://github.com/rubynz">
       <i class="fa fa-github fa-3x" alt="Ruby NZ Github"></i>

--- a/index.html
+++ b/index.html
@@ -22,12 +22,12 @@ layout: default
 <section class="pure-g" id="join-the-community">
   <div class="pure-u-1">
     <h2>Join the Community</h2>
-    <p>For code chat, job listings, ruby help, keyboard nerdery, and banter, join us on <a href="https://slack.ruby.nz">Ruby Oceania Slack</a>.</p>
+    <p>For code chat, job listings, ruby help, keyboard nerdery, and banter, join us on <a href="mailto:secretary@ruby.nz?subject=Can I have Ruby Oceania Slack access please?">Ruby Oceania Slack</a>.</p>
 
     <p></p>
   </div>
   <div class="pure-u-1 social">
-    <a href="https://slack.ruby.nz">
+    <a href="mailto:secretary@ruby.nz?subject=Can I have Ruby Oceania Slack access please?">
       <i class="fa fa-slack fa-3x" alt="Ruby NZ Slack"></i>
     </a>
     <a href="https://github.com/rubynz">


### PR DESCRIPTION
Back to emails.

Context: https://rubyau.slack.com/archives/GB83X48D8/p1743995355136999?thread_ts=1743993651.625799&cid=GB83X48D8

TLDR; We should not expose the public invite link, so back to emails as a simple gate keeper.