### PR TITLE
Update committee members, past and present

### DIFF
--- a/index.html
+++ b/index.html
@@ -94,15 +94,15 @@ layout: default
 
 <section id="current-committee">
   <h2>Current Committee</h2>
-  <p>After the vote held during the AGM held on June 25, 2024 the committee was:</p>
+  <p>After the vote held during the AGM held on May 10, 2025 the committee was:</p>
   <ul>
-    <li><strong>President:</strong> Sarah Hay</li>
+    <li><strong>Chairperson:</strong> Nick Malcolm</li>
     <li><strong>Secretary:</strong> Michael Yin</li>
     <li><strong>Treasurer:</strong> Philip Arndt</li>
     <li>
       <strong>General Members:</strong>
       <ul>
-        <li>Mark Haylock</li>
+        <li>Jonathan Arndt</li>
         <li>Henry James Maddocks</li>
         <li>Nathan Broadbent</li>
         <li>Ben Tillman</li>
@@ -122,15 +122,15 @@ layout: default
 <section id="past-committee">
   <h2>Past Committee Members</h2>
   <ul>
-    <li>Ben Tillman (president 2021-2023, general member 2023-2024)</li>
-    <li>Michael Yin (secretary 2021-2024)</li>
-    <li>Mark Haylock (general member 2021-2024)</li>
+    <li>Ben Tillman (president 2021-2023, general member 2023-present)</li>
+    <li>Philip Arndt (president 2014-2016, treasurer 2020-2021, treasurer 2022-present)</li>
+    <li>Sarah Hay (general member 2021-2023, president 2023-2025)</li>
+    <li>Mark Haylock (general member 2021-2025)</li>
     <li>Matthew Wratt (general member 2022-2024)</li>
     <li>Hannah Oldroyd (treasurer 2021-2022)</li>
     <li>Eaden McKee (general member 2021-2022)</li>
     <li>Edu Depetris (general member 2021-2022)</li>
     <li>Dan Lawler (general member 2021-2022)</li>
-    <li>Sarah Hay (general member 2021-2023, president 2023-2024)</li>
     <li>Pete Nicholls(secretary 2020-2021)</li>
     <li>Rebecca Pinheiro (general member 2020-2021)</li>
     <li>Dmitry Rocha (general member 2020-2021)</li>
@@ -152,7 +152,6 @@ layout: default
     <li>Raquel Moss (president 2017-2018, general member 2016-2017)</li>
     <li>Merrin Macleod (secretary 2014-2015, general member 2016-2017, president 2020-2021)</li>
     <li>Eoin Kelly (treasurer 2014-2016)</li>
-    <li>Philip Arndt (president 2014-2016, treasurer 2020-2021, treasurer 2022-2024)</li>
     <li>Megan Bowra-Dean (general member 2015-2016)</li>
     <li>James Harton (general member 2014-2016)</li>
     <li>Breccan McLeod-Lundy (general member 2014-2015)</li>
@@ -164,6 +163,7 @@ layout: default
   <h2>Slack Moderators</h2>
   Members of the committee moderate Slack to make sure that we're all following the Code of Conduct. If you have questions or concerns, you can contact our moderators on Slack. They might not always be online, so send them a direct message if you need to talk to them.
   <ul>
+    <li>@Nick Malcolm</li>
     <li>@Ben Tillman</li>
     <li>@Henry</li>
     <li>@Mark Haylock</li>


### PR DESCRIPTION
Part of https://github.com/rubynz/www/issues/94

- Updates the current committee members
- Moves Mark to the past committee member section
- Reorders the past committee section so that current committee members who have past and present roles are at the top