### PR TITLE
Update Wellington link to ruby.nz domain

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,7 +50,7 @@ layout: default
       This is a monthly group that explores the use of Ruby. Welcomes anyone interested in the language!
     </li>
     <li>
-      <a href="http://wellington.ruby.org.nz">Wellington</a>:
+      <a href="https://wellington.ruby.nz">Wellington</a>:
       Meets every second month, generally with planned talks, food and drinks provided.
     </li>
     <li>


### PR DESCRIPTION
Wellington was still on the ruby.org.nz domain. It looks like ruby.nz is the new thing so I've moved it over there (as I'm going to build out more of a website), creating a broken link on the website.